### PR TITLE
feat: 'addon' property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ API
 | disabledSeconds         | Function                          | disabled second options                       |                                                                                            |
 | hideDisabledOptions     | Boolean                           | whether hide disabled options                 |                                                                                            |
 | onChange                | Function                          | null                                          | called when select a different value                                                       |
+| addon                   | Function                          | nothing                                       | called from timepicker panel to render some addon to its bottom, like an OK button. Receives panel instance as parameter, to be able to close it like `panel.close()`.|
 | placement               | String                            | bottomLeft                                    | one of ['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'] |
 | transitionName          | String                            | ''                                            |                                                                                            |
 

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -36,6 +36,7 @@ const Panel = React.createClass({
     showHour: PropTypes.bool,
     showSecond: PropTypes.bool,
     onClear: PropTypes.func,
+    addon: PropTypes.func,
   },
 
   getDefaultProps() {
@@ -47,6 +48,7 @@ const Panel = React.createClass({
       disabledMinutes: noop,
       disabledSeconds: noop,
       defaultOpenValue: moment(),
+      addon: noop,
     };
   },
 
@@ -79,11 +81,15 @@ const Panel = React.createClass({
     this.setState({ currentSelectPanel });
   },
 
+  close() {
+    this.props.onEsc();
+  },
+
   render() {
     const {
       prefixCls, className, placeholder, disabledHours, disabledMinutes,
       disabledSeconds, hideDisabledOptions, allowEmpty, showHour, showSecond,
-      format, defaultOpenValue, clearText, onEsc,
+      format, defaultOpenValue, clearText, onEsc, addon,
     } = this.props;
     const {
       value, currentSelectPanel,
@@ -133,6 +139,7 @@ const Panel = React.createClass({
           disabledSeconds={disabledSeconds}
           onCurrentSelectPanelChange={this.onCurrentSelectPanelChange}
         />
+        {addon(this)}
       </div>
     );
   },

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -39,6 +39,7 @@ const Picker = React.createClass({
     onChange: PropTypes.func,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
+    addon: PropTypes.func,
   },
 
   getDefaultProps() {
@@ -61,6 +62,7 @@ const Picker = React.createClass({
       onChange: noop,
       onOpen: noop,
       onClose: noop,
+      addon: noop,
     };
   },
 
@@ -137,6 +139,7 @@ const Picker = React.createClass({
       prefixCls, placeholder, disabledHours,
       disabledMinutes, disabledSeconds, hideDisabledOptions,
       allowEmpty, showHour, showSecond, defaultOpenValue, clearText,
+      addon,
     } = this.props;
     return (
       <Panel
@@ -157,6 +160,7 @@ const Picker = React.createClass({
         disabledMinutes={disabledMinutes}
         disabledSeconds={disabledSeconds}
         hideDisabledOptions={hideDisabledOptions}
+        addon={addon}
       />
     );
   },


### PR DESCRIPTION
..to be able to render something like OK button to timepicker:
```
            <TimePicker
              allowEmpty={false}
              addon={panel => {
                return (
                  <div className="row">
                    <a role="button" className="btn btn-sm btn-default" onClick={() => panel.close()}>
                      {__('OK')}
                    </a>
                  </div>
                )
              }}
            />

```
