### PR TITLE
Fix react error about refs

### DIFF
--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -69,6 +69,7 @@ const Picker = React.createClass({
   },
 
   getInitialState() {
+    this.saveInputRef = refFn.bind(this, 'picker');
     this.savePanelRef = refFn.bind(this, 'panelInstance');
     const { defaultOpen, defaultValue, open = defaultOpen, value = defaultValue } = this.props;
     return {
@@ -104,7 +105,7 @@ const Picker = React.createClass({
 
   onEsc() {
     this.setOpen(false);
-    this.refs.picker.focus();
+    this.picker.focus();
   },
 
   onKeyDown(e) {
@@ -212,7 +213,7 @@ const Picker = React.createClass({
         <span className={`${prefixCls} ${className}`} style={style}>
           <input
             className={`${prefixCls}-input`}
-            ref="picker" type="text" placeholder={placeholder}
+            ref={this.saveInputRef} type="text" placeholder={placeholder}
             readOnly
             onKeyDown={this.onKeyDown}
             disabled={disabled} value={value && value.format(this.getFormat()) || ''}


### PR DESCRIPTION
When building master from source I got this error:

    Uncaught Error: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
        at invariant (invariant.js:44)
        at Object.addComponentAsRefTo (ReactOwner.js:68)
        at attachRef (ReactRef.js:23)
        at Object.ReactRef.attachRefs (ReactRef.js:42)
        at ReactDOMComponent.attachRefs (ReactReconciler.js:23)
        at CallbackQueue.notifyAll (CallbackQueue.js:76)
        at ReactReconcileTransaction.close (ReactReconcileTransaction.js:80)
        at ReactReconcileTransaction.closeAll (Transaction.js:206)
        at ReactReconcileTransaction.perform (Transaction.js:153)
        at batchedMountComponentIntoNode (ReactMount.js:126)

After that the other scripts on the page do not work normally anymore.
This PR fixes the error.