### PR TITLE
make header input readonly by an optional prop

### DIFF
--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -10,6 +10,7 @@ class Header extends Component {
     placeholder: PropTypes.string,
     clearText: PropTypes.string,
     value: PropTypes.object,
+    readOnlyInput: PropTypes.bool,
     hourOptions: PropTypes.array,
     minuteOptions: PropTypes.array,
     secondOptions: PropTypes.array,
@@ -25,6 +26,10 @@ class Header extends Component {
     focusOnOpen: PropTypes.bool,
     onKeyDown: PropTypes.func,
   };
+
+  static defaultProps = {
+    readOnlyInput: false,
+  }
 
   constructor(props) {
     super(props);
@@ -166,7 +171,7 @@ class Header extends Component {
   }
 
   getInput() {
-    const { prefixCls, placeholder } = this.props;
+    const { prefixCls, placeholder, readOnlyInput } = this.props;
     const { invalid, str } = this.state;
     const invalidClass = invalid ? `${prefixCls}-input-invalid` : '';
     return (
@@ -177,6 +182,7 @@ class Header extends Component {
         value={str}
         placeholder={placeholder}
         onChange={this.onInputChange}
+        readOnly={!!readOnlyInput}
       />
     );
   }

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -27,6 +27,7 @@ class Panel extends Component {
     value: PropTypes.object,
     placeholder: PropTypes.string,
     format: PropTypes.string,
+    readOnlyInput: PropTypes.bool,
     disabledHours: PropTypes.func,
     disabledMinutes: PropTypes.func,
     disabledSeconds: PropTypes.func,
@@ -58,6 +59,7 @@ class Panel extends Component {
     use12Hours: false,
     addon: noop,
     onKeyDown: noop,
+    readOnlyInput: false,
   };
 
   constructor(props) {
@@ -96,7 +98,7 @@ class Panel extends Component {
       prefixCls, className, placeholder, disabledHours, disabledMinutes,
       disabledSeconds, hideDisabledOptions, allowEmpty, showHour, showMinute, showSecond,
       format, defaultOpenValue, clearText, onEsc, addon, use12Hours, onClear,
-      focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep,
+      focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep, readOnlyInput,
     } = this.props;
     const {
       value, currentSelectPanel,
@@ -137,6 +139,7 @@ class Panel extends Component {
           allowEmpty={allowEmpty}
           focusOnOpen={focusOnOpen}
           onKeyDown={onKeyDown}
+          readOnlyInput={readOnlyInput}
         />
         <Combobox
           prefixCls={prefixCls}

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -18,6 +18,7 @@ export default class Picker extends Component {
     clearText: PropTypes.string,
     value: PropTypes.object,
     defaultOpenValue: PropTypes.object,
+    readOnlyInput: PropTypes.bool,
     disabled: PropTypes.bool,
     allowEmpty: PropTypes.bool,
     defaultValue: PropTypes.object,
@@ -60,6 +61,7 @@ export default class Picker extends Component {
     clearText: 'clear',
     prefixCls: 'rc-time-picker',
     defaultOpen: false,
+    readOnlyInput: false,
     style: {},
     className: '',
     popupClassName: '',
@@ -167,7 +169,7 @@ export default class Picker extends Component {
   getPanelElement() {
     const {
       prefixCls, placeholder, disabledHours,
-      disabledMinutes, disabledSeconds, hideDisabledOptions,
+      disabledMinutes, disabledSeconds, hideDisabledOptions, readOnlyInput,
       allowEmpty, showHour, showMinute, showSecond, defaultOpenValue, clearText,
       addon, use12Hours, focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep,
     } = this.props;
@@ -177,6 +179,7 @@ export default class Picker extends Component {
         prefixCls={`${prefixCls}-panel`}
         ref={this.savePanelRef}
         value={this.state.value}
+        readOnlyInput={readOnlyInput}
         onChange={this.onPanelChange}
         onClear={this.onPanelClear}
         defaultOpenValue={defaultOpenValue}


### PR DESCRIPTION
I can manually enter such string as "14:30:37ddddd". It's not causing any bugs because of validation. But it looks weird.
I'd like to have a possibility to make that field readonly. It's easier than control key down inputs.