### PR TITLE
 Add a readOnly property to avoid virtual keyboard on touch devices. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ API
 | minuteStep              | Number                            | 1 | interval between minutes in picker  |
 | secondStep              | Number                            | 1 | interval between seconds in picker  |
 | focusOnOpen             | Boolean                           | false | automatically focus the input when the picker opens |
+| readOnly                | Boolean                           | false | Making the input field readonly will avoid showing a virtual keyboard on touch devices. |
 
 ## Test Case
 

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -23,6 +23,7 @@ class Header extends Component {
     defaultOpenValue: PropTypes.object,
     currentSelectPanel: PropTypes.string,
     focusOnOpen: PropTypes.bool,
+    readOnly: PropTypes.bool,
     onKeyDown: PropTypes.func,
   };
 
@@ -177,6 +178,7 @@ class Header extends Component {
         value={str}
         placeholder={placeholder}
         onChange={this.onInputChange}
+        readOnly={this.props.readOnly}
       />
     );
   }

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -44,6 +44,7 @@ class Panel extends Component {
     secondStep: PropTypes.number,
     addon: PropTypes.func,
     focusOnOpen: PropTypes.bool,
+    readOnly: PropTypes.bool,
     onKeyDown: PropTypes.func,
   };
 
@@ -96,7 +97,7 @@ class Panel extends Component {
       prefixCls, className, placeholder, disabledHours, disabledMinutes,
       disabledSeconds, hideDisabledOptions, allowEmpty, showHour, showMinute, showSecond,
       format, defaultOpenValue, clearText, onEsc, addon, use12Hours, onClear,
-      focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep,
+      focusOnOpen, readOnly, onKeyDown, hourStep, minuteStep, secondStep,
     } = this.props;
     const {
       value, currentSelectPanel,
@@ -136,6 +137,7 @@ class Panel extends Component {
           onClear={onClear}
           allowEmpty={allowEmpty}
           focusOnOpen={focusOnOpen}
+          readOnly={readOnly}
           onKeyDown={onKeyDown}
         />
         <Combobox

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -52,6 +52,7 @@ export default class Picker extends Component {
     minuteStep: PropTypes.number,
     secondStep: PropTypes.number,
     focusOnOpen: PropTypes.bool,
+    readOnly: PropTypes.bool,
     onKeyDown: PropTypes.func,
     autoFocus: PropTypes.bool,
   };
@@ -82,6 +83,7 @@ export default class Picker extends Component {
     addon: noop,
     use12Hours: false,
     focusOnOpen: false,
+    readOnly: false,
     onKeyDown: noop,
   };
 
@@ -169,7 +171,7 @@ export default class Picker extends Component {
       prefixCls, placeholder, disabledHours,
       disabledMinutes, disabledSeconds, hideDisabledOptions,
       allowEmpty, showHour, showMinute, showSecond, defaultOpenValue, clearText,
-      addon, use12Hours, focusOnOpen, onKeyDown, hourStep, minuteStep, secondStep,
+      addon, use12Hours, focusOnOpen, readOnly, onKeyDown, hourStep, minuteStep, secondStep,
     } = this.props;
     return (
       <Panel
@@ -197,6 +199,7 @@ export default class Picker extends Component {
         secondStep={secondStep}
         addon={addon}
         focusOnOpen={focusOnOpen}
+        readOnly={readOnly}
         onKeyDown={onKeyDown}
       />
     );


### PR DESCRIPTION
Making the <input> field readonly will avoid showing a virtual keyboard on touch devices.