### PR TITLE
Page input field should follow the readOnly input prop.

### DIFF
--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -255,7 +255,7 @@ export default class Picker extends Component {
     const {
       prefixCls, placeholder, placement, align,
       disabled, transitionName, style, className, getPopupContainer, name, autoComplete,
-      onFocus, onBlur, autoFocus,
+      onFocus, onBlur, autoFocus, inputReadOnly
     } = this.props;
     const { open, value } = this.state;
     const popupClassName = this.getPopupClassName();

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -289,7 +289,8 @@ export default class Picker extends Component {
             onBlur={onBlur}
             autoFocus={autoFocus}
             onChange={noop}
-          />
+            readOnly={!!inputReadOnly}
+            />
           <span className={`${prefixCls}-icon`}/>
         </span>
       </Trigger>


### PR DESCRIPTION
Without this mobile devices will briefly flash a virtual keyboard that then goes away.