### PR TITLE
Allow to update defaultValue

### DIFF
--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -97,8 +97,12 @@ export default class Picker extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { value, open } = nextProps;
-    if ('value' in nextProps) {
+    const { value, open, defaultValue } = nextProps;
+    if('defaultValue' in nextProps) {
+      this.setState({
+        value: defaultValue
+      });
+    }else if ('value' in nextProps) {
       this.setState({
         value,
       });


### PR DESCRIPTION
When we are using this control in React + Redux. It is very common that, defaultValue can be at first null or undefined and then later through redux-store (selector), we get some value to render as default value.