### PR TITLE
Add mulit format support to TimePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ API
 | showHour                | Boolean                           | true | whether show hour | |
 | showMinute              | Boolean                           | true | whether show minute |
 | showSecond              | Boolean                           | true | whether show second |
-| format                  | String                            | - | moment format |
+| format                  | String or String[]                | - | moment format |
 | disabledHours           | Function                          | - | disabled hour options |
 | disabledMinutes         | Function                          | - | disabled minute options |
 | disabledSeconds         | Function                          | - | disabled second options |

--- a/examples/multiFormat.js
+++ b/examples/multiFormat.js
@@ -1,0 +1,22 @@
+/* eslint no-console:0 */
+
+import 'rc-time-picker/assets/index.less';
+
+import React from 'react';
+import ReactDom from 'react-dom';
+
+import moment from 'moment';
+
+import TimePicker from 'rc-time-picker';
+
+const format = ['h:mm a', 'h:mm a', 'HH:mm a', 'h:mm', 'HH:mm', 'hhmm', 'HHmm'];
+
+const now = moment().hour(3).minute(0);
+
+ReactDom.render(
+  <TimePicker
+    defaultValue={now}
+    format={format}
+  />,
+  document.getElementById('__react-content')
+);

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Select from './Select';
+import { getTimeFormat } from './util';
 
 const formatOption = (option, disabledOptions) => {
   let value = `${option}`;
@@ -21,7 +22,7 @@ const formatOption = (option, disabledOptions) => {
 
 class Combobox extends Component {
   static propTypes = {
-    format: PropTypes.string,
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     defaultOpenValue: PropTypes.object,
     prefixCls: PropTypes.string,
     value: PropTypes.object,
@@ -148,7 +149,8 @@ class Combobox extends Component {
   }
 
   getAMPMSelect() {
-    const { prefixCls, use12Hours, format } = this.props;
+    const { prefixCls, use12Hours } = this.props;
+    const format = getTimeFormat(this.props.format);
     if (!use12Hours) {
       return null;
     }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { formatTime } from './util';
 
 class Header extends Component {
   static propTypes = {
-    format: PropTypes.string,
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     prefixCls: PropTypes.string,
     disabledDate: PropTypes.func,
     placeholder: PropTypes.string,
@@ -36,7 +37,7 @@ class Header extends Component {
     super(props);
     const { value, format } = props;
     this.state = {
-      str: value && value.format(format) || '',
+      str: formatTime(value, format),
       invalid: false,
     };
   }
@@ -55,7 +56,7 @@ class Header extends Component {
   componentWillReceiveProps(nextProps) {
     const { value, format } = nextProps;
     this.setState({
-      str: value && value.format(format) || '',
+      str: formatTime(value, format),
       invalid: false,
     });
   }

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -26,7 +26,7 @@ class Panel extends Component {
     defaultOpenValue: PropTypes.object,
     value: PropTypes.object,
     placeholder: PropTypes.string,
-    format: PropTypes.string,
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     inputReadOnly: PropTypes.bool,
     disabledHours: PropTypes.func,
     disabledMinutes: PropTypes.func,

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -4,6 +4,7 @@ import Trigger from 'rc-trigger';
 import Panel from './Panel';
 import placements from './placements';
 import moment from 'moment';
+import { formatTime } from './util';
 
 function noop() {
 }
@@ -29,7 +30,7 @@ export default class Picker extends Component {
     transitionName: PropTypes.string,
     getPopupContainer: PropTypes.func,
     placeholder: PropTypes.string,
-    format: PropTypes.string,
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     showHour: PropTypes.bool,
     showMinute: PropTypes.bool,
     showSecond: PropTypes.bool,
@@ -289,7 +290,7 @@ export default class Picker extends Component {
             name={name}
             onKeyDown={this.onKeyDown}
             disabled={disabled}
-            value={value && value.format(this.getFormat()) || ''}
+            value={formatTime(value, this.getFormat())}
             autoComplete={autoComplete}
             onFocus={onFocus}
             onBlur={onBlur}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,14 @@
+
+export function getTimeFormat(format) {
+  if (Array.isArray(format)) {
+    return format.length ? format[0] : undefined;
+  }
+  return format;
+}
+
+export function formatTime(value, format) {
+  if (!value) {
+    return '';
+  }
+  return value.format(getTimeFormat(format));
+}

--- a/tests/Header.spec.jsx
+++ b/tests/Header.spec.jsx
@@ -60,7 +60,6 @@ describe('Header', () => {
         expect(picker.state.open).to.be(true);
         expect((header).value).to.be('12:34:56');
         expect((input).value).to.be('12:34:56');
-
         next();
       }], () => {
         done();

--- a/tests/TimePicker.spec.jsx
+++ b/tests/TimePicker.spec.jsx
@@ -253,4 +253,60 @@ describe('TimePicker', () => {
       });
     });
   });
+
+  describe('time formats', () => {
+    it('supports single format', (done) => {
+      const picker = renderPickerWithoutSeconds({
+        format: 'h:mm a',
+      });
+      const input = TestUtils.scryRenderedDOMComponentsWithClass(picker,
+        'rc-time-picker-input')[0];
+      async.series([(next) => {
+        Simulate.click(input);
+        setTimeout(next, 100);
+      }, (next) => {
+        expect(TestUtils.scryRenderedDOMComponentsWithClass(picker.panelInstance,
+          'rc-time-picker-panel-inner')[0]).to.be.ok();
+        expect(picker.state.open).to.be(true);
+        const innerInput = TestUtils.scryRenderedDOMComponentsWithClass(picker,
+          'rc-time-picker-panel-input')[0];
+        (innerInput).value = '8:34 am';
+        setTimeout(next, 100);
+      }, (next) => {
+        expect(input).to.be.ok();
+        expect((input).value).to.be('8:24 am');
+        next();
+      }], () => {
+        done();
+      });
+    });
+
+    it('supports an array of formats', (done) => {
+      const picker = renderPickerWithoutSeconds({
+        format: ['h:mm', 'h:mm a'],
+      });
+      const input = TestUtils.scryRenderedDOMComponentsWithClass(picker,
+        'rc-time-picker-input')[0];
+      async.series([(next) => {
+        Simulate.click(input);
+        setTimeout(next, 100);
+      }, (next) => {
+        (input).value = '8:34';
+        setTimeout(next, 100);
+      }, (next) => {
+        expect(input).to.be.ok();
+        expect((input).value).to.be('8:34');
+        next();
+      }, (next) => {
+        (input).value = '8:34 pm';
+        setTimeout(next, 100);
+      }, (next) => {
+        expect(input).to.be.ok();
+        expect((input).value).to.be('8:34 pm');
+        next();
+      }], () => {
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allows format prop to allow an array of formats. The control then uses the array of formats when parsing a date from the input. The first value of the array determines the displayed format.

An example use case is that a user may want to enter a time as hmm but display as h:mm a.