### PR TITLE
When selecting an item, center it instead of scrolling to the top of the list

### DIFF
--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -116,7 +116,7 @@ class Select extends Component {
       index = 0;
     }
     const topOption = list.children[index];
-    const to = topOption.offsetTop;
+    const to = topOption.offsetTop + topOption.offsetHeight / 2 - select.offsetHeight / 2;
     scrollTo(select, to, duration);
   }
 


### PR DESCRIPTION
This is either a feature or a bugfix, or a change of spec, depending on what the current spec is.

The issue I'm having is that when I go to the time picker, for example at https://ant.design/components/time-picker/ and I use the 12 hours time picker, when I click to open it, this is what I see:
<img width="187" alt="Screen Shot 2019-10-03 at 7 15 02 PM" src="https://user-images.githubusercontent.com/1617767/66176329-22411080-e612-11e9-908d-974bb9a35fa9.png">

I don't see the "am" option. It's hidden because the time picker scrolls to whatever option is selected and puts it at the top of the view.

My change centers it in the view instead of putting it at the top, like this:
![2019-08-05 16 48 11](https://user-images.githubusercontent.com/1617767/66176383-5e747100-e612-11e9-9e8e-62b084dd4082.gif)

