### PR TITLE
Add a `formatHours` prop to allow hours in picker to be formatted

### DIFF
--- a/examples/12hours.js
+++ b/examples/12hours.js
@@ -10,22 +10,36 @@ import moment from 'moment';
 import TimePicker from 'rc-time-picker';
 
 const format = 'h:mm a';
+const formatHours = 'h a';
 
-const now = moment().hour(0).minute(0);
+const now = moment()
+  .hour(0)
+  .minute(0);
 
 function onChange(value) {
   console.log(value && value.format(format));
 }
 
 ReactDom.render(
-  <TimePicker
-    showSecond={false}
-    defaultValue={now}
-    className="xxx"
-    onChange={onChange}
-    format={format}
-    use12Hours
-    inputReadOnly
-  />,
-  document.getElementById('__react-content')
+  <div>
+    <TimePicker
+      showSecond={false}
+      defaultValue={now}
+      className="xxx"
+      onChange={onChange}
+      format={format}
+      use12Hours
+      inputReadOnly
+    />
+    <TimePicker
+      showSecond={false}
+      defaultValue={now}
+      className="xxx"
+      onChange={onChange}
+      format={format}
+      formatHours={formatHours}
+      inputReadOnly
+    />
+  </div>,
+  document.getElementById('__react-content'),
 );

--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import Select from './Select';
 
-const formatOption = (option, disabledOptions) => {
+const formatOption = (option, disabledOptions, label) => {
   let value = `${option}`;
   if (option < 10) {
     value = `0${option}`;
@@ -15,6 +16,7 @@ const formatOption = (option, disabledOptions) => {
 
   return {
     value,
+    label,
     disabled,
   };
 };
@@ -22,6 +24,7 @@ const formatOption = (option, disabledOptions) => {
 class Combobox extends Component {
   static propTypes = {
     format: PropTypes.string,
+    formatHours: PropTypes.string,
     defaultOpenValue: PropTypes.object,
     prefixCls: PropTypes.string,
     value: PropTypes.object,
@@ -109,7 +112,7 @@ class Combobox extends Component {
     return (
       <Select
         prefixCls={prefixCls}
-        options={hourOptionsAdj.map(option => formatOption(option, disabledOptions))}
+        options={hourOptionsAdj.map(option => this.formatHour(option, disabledOptions))}
         selectedIndex={hourOptionsAdj.indexOf(hourAdj)}
         type="hour"
         onSelect={this.onItemChange}
@@ -200,6 +203,15 @@ class Combobox extends Component {
         onEsc={onEsc}
       />
     );
+  }
+
+  formatHour(option, disabledOptions) {
+    const { formatHours } = this.props;
+    let label;
+    if (formatHours) {
+      label = moment(option, 'H').format(formatHours);
+    }
+    return formatOption(option, disabledOptions, label);
   }
 
   render() {

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -39,6 +39,7 @@ class Panel extends Component {
     value: PropTypes.object,
     placeholder: PropTypes.string,
     format: PropTypes.string,
+    formatHours: PropTypes.string,
     inputReadOnly: PropTypes.bool,
     disabledHours: PropTypes.func,
     disabledMinutes: PropTypes.func,
@@ -143,6 +144,7 @@ class Panel extends Component {
       showMinute,
       showSecond,
       format,
+      formatHours,
       defaultOpenValue,
       clearText,
       onEsc,
@@ -212,6 +214,7 @@ class Panel extends Component {
           value={value}
           defaultOpenValue={validDefaultOpenValue}
           format={format}
+          formatHours={formatHours}
           onChange={this.onChange}
           onAmPmChange={this.onAmPmChange}
           showHour={showHour}

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -83,7 +83,7 @@ class Select extends Component {
           tabIndex="0"
           onKeyDown={onKeyDown}
         >
-          {item.value}
+          {item.label || item.value}
         </li>
       );
     });

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -31,6 +31,7 @@ export default class Picker extends Component {
     getPopupContainer: PropTypes.func,
     placeholder: PropTypes.string,
     format: PropTypes.string,
+    formatHours: PropTypes.string,
     showHour: PropTypes.bool,
     showMinute: PropTypes.bool,
     showSecond: PropTypes.bool,
@@ -190,6 +191,7 @@ export default class Picker extends Component {
       showHour,
       showMinute,
       showSecond,
+      formatHours,
       defaultOpenValue,
       clearText,
       addon,
@@ -217,6 +219,7 @@ export default class Picker extends Component {
         showSecond={showSecond}
         onEsc={this.onEsc}
         format={this.getFormat()}
+        formatHours={formatHours}
         placeholder={placeholder}
         disabledHours={disabledHours}
         disabledMinutes={disabledMinutes}


### PR DESCRIPTION
The problem we're trying to solve here is that it's possible to format the time that's in the input box, but it's not possible to format each individual numbers in each drop down list (hours, minutes and seconds).

We have a need to format the hours so that they include "AM/PM". We actually don't want to use the `use12Hours` prop because we don't want an "AM/PM" selector. What we want is to show 24 hours in the hours selector, but formatted to show the am/pm suffix, such as `1 pm` or `3 am`. This way we can limit the number of dropdowns to two and it's better for our users for this particular use case.

It looks like this:
<img width="201" alt="63124738-d4d4eb00-bf60-11e9-958c-add7ad663a42" src="https://user-images.githubusercontent.com/1617767/66176795-eeff8100-e613-11e9-85f2-c49506d9909d.png">


I'm looking for feedback on the approach. Once it's validated, I can add unit tests to keep coverage the same.