### PR TITLE
Update Type definitions to with getPopupContainer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ declare module "rc-time-picker" {
     inputReadOnly?: boolean;
     inputIcon?: React.ReactNode;
     clearIcon?: React.ReactNode;
+    getPopupContainer?: (node: HTMLElement) => HTMLElement;
   };
   export default class TimePicker extends React.Component<TimePickerProps> {
     focus(): void;


### PR DESCRIPTION
`TimePicker` takes a `getPopupContainer` which is passed directly through to `Trigger` from `rc-trigger`.

This change copies the type definition from `Trigger.getPopupContainer` to `TimePicker`.