### PR TITLE
Update onChange typing to include default type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ declare module "rc-time-picker" {
     disabledSeconds?: (hour: number, minute: number) => number[];
     use12Hours?: boolean;
     hideDisabledOptions?: boolean;
-    onChange?: (newValue: Moment) => void;
+    onChange?: (newValue: Moment | null) => void;
     onAmPmChange?: (ampm: 'PM' | 'AM') => void;
     addon?: (instance: typeof Panel) => React.ReactNode;
     placement?: string;


### PR DESCRIPTION
As specified in the [README](https://github.com/react-component/time-picker#timepicker-1), the default value for `value` is `null`, even though normally it will be of type `Moment`.

However, the `onChange` handler type is specified to always return a Moment:
```tsx
onChange?: (newValue: Moment) => void;
```

I have updated the type to be a union type of `Moment | null` which properly handles the default value case returning from `onChange`.

Does any additional work need to be done to push these changes to `@types/rc-time-picker`? That is currently what I am using.