### PR TITLE
bump rc-trigger to upgrade rc-animate and fix lifecycle warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-time-picker",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "description": "React TimePicker",
   "keywords": [
     "react",
@@ -35,7 +35,7 @@
     "classnames": "2.x",
     "moment": "2.x",
     "raf": "^3.4.1",
-    "rc-trigger": "^4.0.0-alpha.4"
+    "rc-trigger": "^4.0.0-alpha.8"
   },
   "devDependencies": {
     "cross-env": "^6.0.0",


### PR DESCRIPTION
- upgrade [rc-trigger v4.0.0-alpha.8](https://github.com/react-component/trigger/releases/tag/v4.0.0-alpha.8)