### PR TITLE
add event to onChange and onAmPmChange

### DIFF
--- a/src/Combobox.jsx
+++ b/src/Combobox.jsx
@@ -19,7 +19,7 @@ const formatOption = (option, disabledOptions) => {
 };
 
 class Combobox extends Component {
-  onItemChange = (type, itemValue) => {
+  onItemChange = (type, itemValue, e) => {
     const {
       onChange,
       defaultOpenValue,
@@ -55,11 +55,11 @@ class Combobox extends Component {
           }
         }
       }
-      onAmPmChange(ampm);
+      onAmPmChange(ampm, e);
     } else {
       value.second(+itemValue);
     }
-    onChange(value);
+    onChange(value, e);
   };
 
   onEnterSelectPanel = range => {

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -56,10 +56,10 @@ class Panel extends Component {
     return null;
   }
 
-  onChange = newValue => {
+  onChange = (newValue, e) => {
     const { onChange } = this.props;
     this.setState({ value: newValue });
-    onChange(newValue);
+    onChange(newValue, e);
   };
 
   onAmPmChange = ampm => {

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -107,7 +107,7 @@ class Select extends Component {
       index = 0;
     }
     const topOption = this.list.children[index];
-    const to = topOption.offsetTop;
+    const to = topOption.offsetTop + topOption.offsetHeight / 2 - this.root.offsetHeight / 2; // align center
     scrollTo(this.root, to, duration);
   }
 

--- a/src/Select.jsx
+++ b/src/Select.jsx
@@ -41,9 +41,9 @@ class Select extends Component {
     }
   }
 
-  onSelect = value => {
+  onSelect = (value, e) => {
     const { onSelect, type } = this.props;
-    onSelect(type, value);
+    onSelect(type, value, e);
   };
 
   getOptions() {
@@ -55,11 +55,11 @@ class Select extends Component {
       });
       const onClick = item.disabled
         ? undefined
-        : () => {
-            this.onSelect(item.value);
+        : (e) => {
+            this.onSelect(item.value, e);
           };
       const onKeyDown = e => {
-        if (e.keyCode === 13) onClick();
+        if (e.keyCode === 13) onClick(e);
         else if (e.keyCode === 27) onEsc();
       };
       return (

--- a/src/TimePicker.jsx
+++ b/src/TimePicker.jsx
@@ -72,13 +72,13 @@ class Picker extends Component {
       : null;
   }
 
-  onPanelChange = value => {
-    this.setValue(value);
+  onPanelChange = (value, e) => {
+    this.setValue(value, e);
   };
 
-  onAmPmChange = ampm => {
+  onAmPmChange = (ampm, e) => {
     const { onAmPmChange } = this.props;
-    onAmPmChange(ampm);
+    onAmPmChange(ampm, e);
   };
 
   onClear = event => {
@@ -102,14 +102,14 @@ class Picker extends Component {
     }
   };
 
-  setValue(value) {
+  setValue(value, e) {
     const { onChange } = this.props;
     if (!('value' in this.props)) {
       this.setState({
         value,
       });
     }
-    onChange(value);
+    onChange(value, e);
   }
 
   getFormat() {


### PR DESCRIPTION
when time-picker is used with react-bootstrap Modals / Popovers / Overlays and you click on time it makes Modals / Popovers / Overlays close because this event happens outside container

the only way to control this by passing event so that it can't be prevented / stopped.
Some people in issues said they need to modify event for some reasons

https://github.com/react-component/time-picker/issues/173
https://github.com/react-component/time-picker/issues/92

feel free to modify pr as i've done it quickly for my own needs.